### PR TITLE
added C-functions that are actually used in pyfprint.c

### DIFF
--- a/pyfprint/pyfprint_cffi.py
+++ b/pyfprint/pyfprint_cffi.py
@@ -75,6 +75,9 @@ int fp_print_data_from_dscv_print(struct fp_dscv_print *print, struct fp_print_d
 uint32_t fp_print_data_get_devtype(struct fp_print_data *data);
 uint16_t fp_print_data_get_driver_id(struct fp_print_data *data);
 int fp_print_data_load(struct fp_dev *dev, enum fp_finger finger, struct fp_print_data **data);
+size_t fp_print_data_get_data(struct fp_print_data *data, unsigned char **ret);
+struct fp_print_data *fp_print_data_from_data(unsigned char *buf, size_t buflen);
+void fp_print_data_free(struct fp_print_data *data);
 
 void fp_img_standardize(struct fp_img *img);
 struct fp_minutia **fp_img_get_minutiae(struct fp_img *img, int *nr_minutiae);

--- a/pyfprint/pyfprint_cffi.py
+++ b/pyfprint/pyfprint_cffi.py
@@ -39,24 +39,51 @@ enum fp_verify_result {
 };
 
 int fp_init(void);
+void fp_exit(void);
 struct fp_dscv_dev **fp_discover_devs(void);
 void fp_dscv_devs_free(struct fp_dscv_dev **devs);
+uint32_t fp_dscv_dev_get_devtype(struct fp_dscv_dev *dev);
+struct fp_driver *fp_dscv_dev_get_driver(struct fp_dscv_dev *dev);
+int fp_dscv_dev_supports_dscv_print(struct fp_dscv_dev *dev, struct fp_dscv_print *print);
+int fp_dscv_dev_supports_print_data(struct fp_dscv_dev *dev, struct fp_print_data *print);
+uint32_t fp_dscv_print_get_devtype(struct fp_dscv_print *print);
+uint16_t fp_dscv_print_get_driver_id(struct fp_dscv_print *print);
+
+
 struct fp_dev *fp_dev_open(struct fp_dscv_dev *ddev);
-int fp_enroll_finger_img(struct fp_dev *dev, struct fp_print_data **print_data, struct fp_img **img);
-void fp_img_free(struct fp_img *img);
-void fp_print_data_free(struct fp_print_data *data);
-int fp_verify_finger_img(struct fp_dev *dev, struct fp_print_data *enrolled_print, struct fp_img **img);
-size_t fp_print_data_get_data(struct fp_print_data *data, unsigned char **ret);
-struct fp_print_data *fp_print_data_from_data(unsigned char *buf, size_t buflen);
 void fp_dev_close(struct fp_dev *dev);
-void fp_exit(void);
 int fp_dev_supports_print_data(struct fp_dev *dev, struct fp_print_data *data);
+uint32_t fp_dev_get_devtype(struct fp_dev *dev);
+struct fp_driver *fp_dev_get_driver(struct fp_dev *dev);
+int fp_dev_get_img_height(struct fp_dev *dev);
+int fp_dev_get_img_width(struct fp_dev *dev);
+int fp_dev_get_nr_enroll_stages(struct fp_dev *dev);
+int fp_dev_supports_dscv_print(struct fp_dev *dev, struct fp_dscv_print *print);
+int fp_dev_supports_identification(struct fp_dev *dev);
+int fp_dev_supports_imaging(struct fp_dev *dev);
+
+uint16_t fp_driver_get_driver_id(struct fp_driver *drv);
+const char *fp_driver_get_full_name(struct fp_driver *drv);
+const char *fp_driver_get_name(struct fp_driver *drv);
+
+int fp_enroll_finger_img(struct fp_dev *dev, struct fp_print_data **print_data, struct fp_img **img);
+int fp_verify_finger_img(struct fp_dev *dev, struct fp_print_data *enrolled_print, struct fp_img **img);
 int fp_identify_finger_img(struct fp_dev *dev, struct fp_print_data **print_gallery, size_t *match_offset, struct fp_img **img);
+
+int fp_print_data_delete(struct fp_dev *dev, enum fp_finger finger);
+int fp_print_data_from_dscv_print(struct fp_dscv_print *print, struct fp_print_data **data);
+uint32_t fp_print_data_get_devtype(struct fp_print_data *data);
+uint16_t fp_print_data_get_driver_id(struct fp_print_data *data);
+int fp_print_data_load(struct fp_dev *dev, enum fp_finger finger, struct fp_print_data **data);
+
 void fp_img_standardize(struct fp_img *img);
 struct fp_minutia **fp_img_get_minutiae(struct fp_img *img, int *nr_minutiae);
 int fp_img_save_to_file(struct fp_img *img, char *path);
 struct fp_img *fp_img_binarize(struct fp_img *img);
 int fp_img_compare_print_data_to_gallery(struct fp_print_data *print, struct fp_print_data **gallery, int match_threshold, size_t *match_offset);
+int fp_img_get_height(struct fp_img *img);
+int fp_img_get_width(struct fp_img *img);
+void fp_img_free(struct fp_img *img);
 
 """)
 


### PR DESCRIPTION
a number of functions from libfprint are using in `pyfprint.py`, but there declaration have been removed from the `pyfprint-cffi.py` file.
this makes the python API broken, e.g. `Device.devtype()` simply errors out.

the patch fixes this by adding all functions that are referenced in `pyfprint.py`.

I also did some re-ordering of the functions to group them together.
