### PR TITLE
fixed exception class

### DIFF
--- a/pyfprint/pyfprint.py
+++ b/pyfprint/pyfprint.py
@@ -112,7 +112,7 @@ class Device:
         """
         if self.dev:
             return C.fp_dev_get_nr_enroll_stages(self.dev)
-        raise FprintIOError("device not open")
+        raise FprintIOException("Device not open")
 
     def is_compatible(self, fprint):
         """


### PR DESCRIPTION
there is no "FprintIOError" class we can raise; it's called "FprintIOException"
